### PR TITLE
RFC-2309: Add support for SciTokens

### DIFF
--- a/roles/htcondor_ce/defaults/main.yml
+++ b/roles/htcondor_ce/defaults/main.yml
@@ -26,3 +26,4 @@ htcondor_ce_apel_db_username: apel
 htcondor_ce_apel_db_password:
 htcondor_ce_apel_site_name:
 htcondor_ce_apel_spec_value: 1.0
+htcondor_ce_scitoken_mappings: []

--- a/roles/htcondor_ce/files/01-ce-auth.conf
+++ b/roles/htcondor_ce/files/01-ce-auth.conf
@@ -1,0 +1,35 @@
+
+###############################################################################
+#
+# HTCondor-CE common authorization configuration
+#
+# This file will NOT be overwritten upon RPM upgrade.
+#
+###############################################################################
+
+# Uncomment the following lines if your SciTokens or SSL clients use
+# grid certificates or your HTCondor-CE's host certificate is located
+# in the standard grid location
+#
+# https://htcondor-ce.readthedocs.io/en/latest/installation/htcondor-ce#configuring-certificates
+
+AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
+AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
+AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
+# AUTH_SSL_SERVER_CAFILE =
+AUTH_SSL_CLIENT_CERTFILE = /etc/grid-security/hostcert.pem
+AUTH_SSL_CLIENT_KEYFILE = /etc/grid-security/hostkey.pem
+AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
+# AUTH_SSL_CLIENT_CAFILE =
+
+
+# By default, regular expressions in the second field of HTCondor-CE
+# mapfiles must be enclosed with '/'. For exmaple:
+#
+# GSI /(.*)/  GSS_ASSIST_GRIDMAP
+#
+# To restore the previous behavior where the second field is enclosed
+# in double-quotes and they are all treated as potential regular
+# expressions, set the following to False:
+#
+# CERTIFICATE_MAPFILE_ASSUME_HASH_KEYS = True

--- a/roles/htcondor_ce/molecule/default/prepare.yml
+++ b/roles/htcondor_ce/molecule/default/prepare.yml
@@ -46,6 +46,7 @@
       include_role:
         name: "grid"
       vars:
+        grid_umd_repo_priority: 98
         grid_umd_repo_exclude:
           - dpm-*
           - lfc-*

--- a/roles/htcondor_ce/tasks/htcondor-ce.yml
+++ b/roles/htcondor_ce/tasks/htcondor-ce.yml
@@ -19,6 +19,10 @@
       dest: config.d/60-job-routes.conf
     - src: local.conf.j2
       dest: config.d/99-local.conf
+    - src: scitokens.conf.j2
+      dest: mapfiles.d/10-scitokens.conf
+    - src: files/01-ce-auth.conf
+      dest: config.d/01-ce-auth.conf
   notify: reconfigure htcondor_ce
 
 - name: Disable WN proxy renewal

--- a/roles/htcondor_ce/templates/scitokens.conf.j2
+++ b/roles/htcondor_ce/templates/scitokens.conf.j2
@@ -1,0 +1,29 @@
+###############################################################################
+#
+# HTCondor-CE manual SciTokens authentication mappings
+#
+# This file will NOT be overwritten upon RPM upgrade.
+#
+###############################################################################
+
+# Authentication of SciTokens and WLCG tokens requires CA certificates
+# installed in the standard system (/etc/pki/tls/certs/ca-bundle.crt)
+# or Grid (/etc/grid-security/certificates) locations. If using Grid
+# certificates, be sure to set 'AUTH_SSL_*' configuration values as
+# appropriate in /etc/condor-ce/config.d/
+
+# To allow clients with SciToken or WLCG tokens to submit jobs to your
+# HTCondor-CE, add lines of the following format:
+#
+# SCITOKENS /<TOKEN ISSUER>,<TOKEN SUBJECT>/ <USERNAME>
+#
+# Where the second field (between the '/') should be a Perl Compatible
+# Regular Expression (PCRE). For example, to map all clients with
+# SciTokens issued by the OSG VO regardless of subject to the local
+# 'osg' user, add the following line to this file:
+#
+# SCITOKENS /^https:\/\/scitokens.org\/osg-connect,.*/ osg
+
+{% for mapping in htcondor_ce_scitoken_mappings %}
+SCITOKENS /{{ mapping.issuer }},{{ mapping.subject }}/ {{ mapping.username }}
+{% endfor %}

--- a/roles/workernode/molecule/default/molecule.yml
+++ b/roles/workernode/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint: |
   flake8
 platforms:
   - name: instance-${INSTANCE_ID:-local}
-    hostname: vobox.grid.vbc.ac.at
+    hostname: cn-1.grid.vbc.ac.at
     image: ${MOLECULE_IMAGE:-'centos/systemd:latest'}
     command: /sbin/init
     capabilities:

--- a/roles/workernode/molecule/default/prepare.yml
+++ b/roles/workernode/molecule/default/prepare.yml
@@ -18,3 +18,9 @@
           - dpm-*
           - lfc-*
           - lcgdm-*
+          - python2-dpm-*
+          - python2-lfc-*
+          - python2-lcgdm-*
+          - gfal2-util-*
+          - xrootd-*
+          - "*condor*"


### PR DESCRIPTION
Add new variable htcondor_ce_scitoken_mappings and scitoken.conf.j2
template to manage support for SciTokens.
Additionally configure HTCondor-CE host certificates in /etc/grid-security