### PR TITLE
COPS-93: Add ability to override date for accounting

### DIFF
--- a/roles/htcondor_ce/files/apel/condor_ce_blah.sh
+++ b/roles/htcondor_ce/files/apel/condor_ce_blah.sh
@@ -15,11 +15,16 @@ safe_config_val () {
     eval "$var"='$val'
 }
 
-today=$(date -u --date='00:00:00 today' +%s)
-yesterday=$(date -u --date='00:00:00 yesterday' +%s)
+DATE='today'
+if [ $# -ge 1 ] && [ -n "$1" ]; then
+    DATE=$1
+fi
+
+today=$(date -u --date="00:00:00 $DATE" +%s)
+yesterday=$(date -u --date="00:00:00 $DATE - 1 day" +%s)
 
 safe_config_val OUTPUT_DIR APEL_OUTPUT_DIR
-OUTPUT_FILE="$OUTPUT_DIR/blahp-$(date -u --date='yesterday' +%Y%m%d )-$(hostname -s)"
+OUTPUT_FILE="$OUTPUT_DIR/blahp-$(date -u --date="$DATE - 1 day" +%Y%m%d )-$(hostname -s)"
 
 if [ ! -d $OUTPUT_DIR ] || [ ! -w $OUTPUT_DIR ]; then
     echo "Cannot write to $OUTPUT_DIR"

--- a/roles/htcondor_ce/files/apel/slurm.sh
+++ b/roles/htcondor_ce/files/apel/slurm.sh
@@ -13,12 +13,17 @@ safe_config_val () {
     eval "$var"='$val'
 }
 
+DATE='today'
+if [ $# -ge 1 ] && [ -n "$1" ]; then
+    DATE=$1
+fi
+
 # Create a temporary accounting file name
-today=$(date -u --date='00:00:00 today' +%FT%T)
-yesterday=$(date -u --date='00:00:00 yesterday' +%FT%T)
+today=$(date -u --date="00:00:00 $DATE" +%FT%T)
+yesterday=$(date -u --date="00:00:00 $DATE -1 day" +%FT%T)
 
 OUTPUT_DIR="$(condor_ce_config_val APEL_OUTPUT_DIR)"
-OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date='yesterday' +%Y%m%d )-$(hostname -s)"
+OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date="$DATE - 1day" +%Y%m%d )-$(hostname -s)"
 
 [[ -d $OUTPUT_DIR && -w $OUTPUT_DIR ]] || fail "Cannot write to $OUTPUT_DIR"
 

--- a/roles/htcondor_ce/templates/local.conf.j2
+++ b/roles/htcondor_ce/templates/local.conf.j2
@@ -6,3 +6,5 @@ TCP_FORWARDING_HOST={{ htcondor_ce_tcp_forwarding_host }}
 {% if htcondor_ce_private_network_name is defined %}PRIVATE_NETWORK_NAME={{ htcondor_ce_private_network_name }}
 {% endif %}
 PRIVATE_NETWORK_INTERFACE={{ ansible_default_ipv4.interface }}
+{% if htcondor_ce_max_history_rotations is defined %}MAX_HISTORY_ROTATIONS = {{ htcondor_ce_max_history_rotations }}
+{% endif %}


### PR DESCRIPTION
Modify the slurm and htcondor apel accounting bash scripts
to take an optional date parameter.
This can be used to generate historic records